### PR TITLE
Exclude wordpress-plugin installation paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "humanmade/core",
 	"description": "Human Made Platform Core Module",
-	"type": "package",
+	"type": "composer-plugin",
 	"license": "GPL-2.0-or-later",
 	"authors": [
 		{
@@ -16,6 +16,14 @@
 		"files": [
 			"inc/namespace.php",
 			"load.php"
-		]
+		],
+		"classmap": [ "inc/" ]
+	},
+	"extra": {
+		"class": "HM\\Platform\\Composer\\Plugin"
+	},
+	"require": {
+		"composer-plugin-api": "^1.0",
+		"composer/installers": "^1.4"
 	}
 }

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace HM\Platform\Composer;
+
+use Composer\Installers\Installer as BaseInstaller;
+use Composer\Package\PackageInterface;
+
+class Installer extends BaseInstaller {
+	public function getInstallPath( PackageInterface $package, $framework_type = '' ) {
+
+		/**
+		 * Allow specific wordpress-plugin packages to skip the wordpress-plugin
+		 * installer. We use this to stop plugins that are bundled with modules are
+		 * not installed to the wp-content/plugins path.
+		 */
+		$excluded_plugins = [
+			'humanmade/smart-media',
+			'humanmade/tachyon-plugin',
+			'humanmade/s3-uploads',
+			'10up/elasticpress',
+		];
+
+		if ( ! in_array( $package->getType(), [ 'wordpress-plugin' ], true ) || ! in_array( $package->getName(), $excluded_plugins, true ) ) {
+			return parent::getInstallPath( $package, $framework_type );
+		}
+
+		$this->initializeVendorDir();
+
+		$base_path = ( $this->vendorDir ? $this->vendorDir . '/' : '' ) . $package->getPrettyName();
+		$target_dir = $package->getTargetDir();
+
+		return $base_path . ( $target_dir ? '/' . $target_dir : '' );
+	}
+}

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -9,7 +9,7 @@ use Composer\Plugin\PluginInterface;
 class Plugin implements PluginInterface {
 
 	/**
-	 * Activate is not used, but is part of the abstract class.
+	 * Called when the plugin is activated.
 	 *
 	 * @param Composer $composer
 	 * @param IOInterface $io

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace HM\Platform\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+class Plugin implements PluginInterface {
+
+	/**
+	 * Activate is not used, but is part of the abstract class.
+	 *
+	 * @param Composer $composer
+	 * @param IOInterface $io
+	 */
+	public function activate( Composer $composer, IOInterface $io ) {
+		$current_installer = $composer->getInstallationManager()->getInstaller( 'wordpress-plugin' );
+		if ( $current_installer ) {
+			$composer->getInstallationManager()->removeInstaller( $current_installer );
+		}
+
+		$installer = new Installer( $io, $composer );
+		$composer->getInstallationManager()->addInstaller( $installer );
+
+	}
+}


### PR DESCRIPTION
When modules depend on packages of type `wordpress-plugin` we don't want to install them to `wp-content/plugins`, but instead just in the `vendor` directory like any typical package. To do this we have to override the Composer Installers class to a patched version that excludes specific plugins from going to their normal location.

Ideally we'd have the list of excluded plugins be pulled from module's `composer.json` files, so we don't need to maintain a centralized list. The problem is I can't find a way get all the cached `package.json` content from the installer location. I'm pretty sure this _is_ in memory at the point of installing any `wordpress-plugin`, but that assumption may not be right. I have a feeling the complete dep graph isn't available until after the Install Manager installs all the packages.

For now, I think we should continue with a hardcoded list, and when someone wants to have a stab at upgrading this to support specifying excluded plugins from a module's `composer.json` then we add support for that.