### PR TITLE
Fix plugin url paths

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -191,6 +191,10 @@ function fix_plugins_url( string $url, string $path, string $plugin ) : string {
 		return $url;
 	}
 
+	if ( ! empty( $path ) ) {
+		$path = '/' . ltrim( $path, '/' );
+	}
+
 	return str_replace( dirname( ABSPATH ), dirname( WP_CONTENT_URL ), dirname( $plugin ) ) . $path;
 }
 


### PR DESCRIPTION
This ensures the path has a trailing slash before it's appended to the plugin directory URL. Issue noticed with AMP plugin.