### PR TITLE
Add check for add_action

### DIFF
--- a/load.php
+++ b/load.php
@@ -8,6 +8,11 @@ namespace HM\Platform;
 // Get module functions.
 require_once __DIR__ . '/inc/namespace.php';
 
+// Don't self-initialize if this is not a Platform execution.
+if ( ! function_exists( 'add_action' ) ) {
+	return;
+}
+
 // Patch plugins URL for vendor directory.
 add_filter( 'plugins_url', 'HM\\Platform\\fix_plugins_url', 10, 3 );
 


### PR DESCRIPTION
Per https://github.com/humanmade/platform-dev/issues/323, we are screwing up any inclusion of autoload.php outside of the wp-config.php. We are discussing a better long term solution in https://github.com/humanmade/platform-dev/pull/325, but this is intended to get things functioning.